### PR TITLE
观看记录多端同步(WatchSync)完善：锚定cid防误删+SQLite直读+墓碑新者胜合并

### DIFF
--- a/app/src/main/java/com/github/catvod/spider/AListSh.java
+++ b/app/src/main/java/com/github/catvod/spider/AListSh.java
@@ -94,6 +94,15 @@ public class AListSh extends Spider {
     @Override
     public String homeContent(boolean filter) throws Exception {
         fetchRule();
+        // 观看记录多端同步：每 AListSh 实例一个 sync，homeContent 首次进入时懒创建并锚定 cid+username。
+        // 不放 start() 静态单例了：实例自持 watchSync 字段，同实例复用，切配置=换 AListSh=换 sync。
+        if (watchSync == null) {
+            try {
+                watchSync = WatchSync.create(mContext, defaultDrive);
+            } catch (Throwable t) {
+                Logger.log("AListSh > WatchSync.create err: " + t);
+            }
+        }
         List<Class> classes = new ArrayList<>();
         for (Drive drive : drives)
             if (!drive.hidden())
@@ -435,9 +444,6 @@ public class AListSh extends Spider {
                 Path.write(wLoginFile, (cUserName + "\n" + cPassword).getBytes());
             }
         }
-        
-        // 观看记录多端同步：FileObserver 监视本地 DB + 30s 拉取 + 启动立即拉一次
-        watchSync = WatchSync.start(mContext, defaultDrive);        
     }
 
     private Drive getDrive(String name) {

--- a/app/src/main/java/com/github/catvod/spider/WatchSync.java
+++ b/app/src/main/java/com/github/catvod/spider/WatchSync.java
@@ -1,6 +1,9 @@
 package com.github.catvod.spider;
 
 import android.content.Context;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
 
 import com.github.catvod.bean.alist.Drive;
 
@@ -9,6 +12,7 @@ import org.json.JSONObject;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,9 +41,9 @@ import java.util.concurrent.TimeUnit;
  *       </ul>
  *       兼容旧格式：若读到的是裸 JSON 数组，则当作 records 处理。</li>
  *   <li><b>统一流程 {@link #pullAndPush()}</b>：本地轮询（3 秒）检测到本机记录变化 / 定时（30 秒）都走它：
- *       读本地 → 与 {@code localSnap} 对比生成墓碑 → 读远端 → 「新者胜」合并（墓碑与记录比时间戳）→ 写回远端（含墓碑）→ 本地入库（historySync 增/改 + historyDel 删墓碑命中的）。</li>
- *   <li>本机全集通过 {@code AppDatabase.get().getHistoryDao().findAll()} 反射获取并过滤当前播放源(cid)，
- *       避免 {@code History.get()} 的 LIMIT 60 截断把"自然淘汰"误判成删除。</li>
+ *       读本地 → 与 {@code localSnap} 对比生成墓碑 → 读远端 → 「新者胜」合并（墓碑与记录比时间戳）→ 写回远端（含墓碑）→ 本地入库（SQL 直写 upsert + SQL 删除。</li>
+ *   <li>本机全集通过 {@code AppDatabase.get().getHistoryDao().findAll()} 反射获取（<b>不过滤 cid/url</b>，
+ *       本机该用户的全部历史都同步进他的 watch.&lt;user&gt;.txt）。cid 在跨设备/跨源下不可靠，已弃用。</li>
  * </ul>
  *
  * <p><b>合并规则（LWW-register：新者胜）</b></p>
@@ -49,6 +53,16 @@ import java.util.concurrent.TimeUnit;
  *   <li>因此"本机仍持有旧副本"不会撤销删除，只有"重新看过（createTime 晚于删除时间）"才会复活。</li>
  *   <li>墓碑带 {@link #TOMBSTONE_TTL_MS} 有效期，过期不再写回远端，避免无限累积。</li>
  * </ol>
+ *
+ * <p><b>锚定模型（cid + username 锁死）</b></p>
+ * <ul>
+ *   <li>每 <b>一个 AListSh 实例对应一个 sync 实例</b>（不单例）：宿主里每个配置一个 AListSh，天然每配置一个 sync。</li>
+ *   <li>sync 在 <b>homeContent 初始化时</b>解析并<b>锚定</b>当前 {@code cid} 与 {@code username}（此刻 cid 可靠稳定），
+ *       实例整个生命周期锁死在这两个值上，不再二次读取。</li>
+ *   <li>远端文件按锚定的 username 隔离存取（watch.&lt;user&gt;.txt）。</li>
+ *   <li>读本地记录：SQLite 全量读表后按<b>记录自带的 cid</b> 过滤（{@code WHERE cid = 锚定cid}），
+ *       基线(墓碑判定)永远在同一 cid 分区内比较——切源即换 AListSh 实例、换 sync，互不污染，杜绝误删。</li>
+ * </ul>
  */
 public class WatchSync {
 
@@ -61,10 +75,19 @@ public class WatchSync {
     private static final long PULL_PERIOD_SEC = 30;
     /** 墓碑有效期（毫秒）：超过该时长不再写回远端，避免墓碑无限累积。 */
     private static final long TOMBSTONE_TTL_MS = 60L * 24 * 60 * 60 * 1000; // 60 天
-
     private final Context context;
     private final Drive drive;
     private final String username;
+    /** 锚定的源 cid：homeContent 初始化时取一次并锁死，本地历史只同步该 cid 分区。 */
+    private int anchorCid = -1;
+    /** cid 防护探测节流（毫秒）：避免每 3 秒轮询都做一次反射。 */
+    private static final long CID_PROBE_MS = 2000L;
+    /** 上次静默探测到的当前源 cid，供防护比对（anchorCid 恒定，此值随切换源变化）。 */
+    private volatile int lastProbeCid = -1;
+    /** 上次探测时间戳，用于节流。 */
+    private volatile long lastProbeAt = 0L;
+    /** 当前是否处于"cid 偏离锚定、本轮整体跳过"状态（只在状态翻转时打日志，避免刷屏）。 */
+    private volatile boolean cidBlocked = false;
     /** 远端同步文件路径（已按用户名隔离）。 */
     private final String syncPath;
 
@@ -75,27 +98,18 @@ public class WatchSync {
     /** 本机上次同步后的历史片名集合（仅内存、不持久化），用于与当前本地对比生成删除墓碑。 */
     private final Set<String> localSnap = new HashSet<>();
 
-    /** 用于记录AList配置的真实cid。 */
-    private int alistCid;
-
     // ---------------- 反射缓存 ----------------
     // 由于 WatchSync 是 spider 插件，运行在宿主播放器内，History 等类是宿主应用的，
     // 因此一律通过反射调用，避免直接编译期依赖。
     private Class<?> historyClass;          // com.fongmi.android.tv.bean.History
-    private Method historyGet;              // History.get() -> 最近 60 条（仅作兜底）
-    private Method historyFindByName;       // History.findByName(String) -> List
-    private Method historyObjectFrom;       // History.objectFrom(String) -> History
-    private Method historySync;             // History.sync(List) -> void（只增/改，不删）
-    private Method histDel;                 // History.delete() -> History（删除单条本地记录）
+    private Method historyGet;              // History.get() -> 最近 60 条（仅兜底，读路径用）
+    private Method historyObjectFrom;       // History.objectFrom(String) -> History（读路径构造用）
     private Method histGetVodName;          // History.getVodName()
-    private Method histCanSave;             // History.canSave()（可为 null）
-    private Method histGetPosition;         // History.getPosition()（可为 null）
-    private Method histGetDuration;         // History.getDuration()（可为 null）
+    private Method histSetCid;              // History.setCid(int) —— 方案2：锚定 cid
+    private Method historySave;             // History.save() —— 方案2：走Room连接写，触发UI自动刷新
 
-    private Object appDb;                   // AppDatabase（或 _Impl）单例实例
-    private Method daoGetter;               // AppDatabase 上取 HistoryDao 的方法
-    private Method daoFindAll;              // HistoryDao 上取全量的方法（findAll/getAll/loadAll）
-    private Method vodGetCid;               // VodConfig.getCid() -> 当前播放源 id（可为 null）
+    private Method vodConfigVod;            // 候选2: Config.vod() -> 当前 vod 配置实例（OK影视等魔改壳）
+    private Method configGetId;             // 候选2: Config.getId() -> 当前配置 id（即锚定的 cid）
 
     /** 远端解析结果。 */
     private static class RemoteData {
@@ -134,12 +148,14 @@ public class WatchSync {
     }
 
     /**
-     * 启动同步。满足条件（drive 非空、syncWatch 开启、syncPath 非空）才初始化：
-     * 解析宿主反射 → 启动本地轮询 + 定时同步 → 首次同步 + 初始化 localSnap 基线。
+     * 创建同步实例（每 AListSh 实例一个，不单例）。由 AListSh.homeContent 首次进入时调用。
+     * <p>关键：在此初始化阶段解析并<b>锚定</b>当前源 cid（此刻 cid 可靠稳定），实例整个生命周期
+     * 锁死在这个 cid + username 上，本地历史只读该 cid 分区，切源即换 AListSh 实例、换 sync，互不污染。</p>
+     * <p>无停机/重建逻辑（不再判定 url.user）：每实例天然锚定，关机/切换由宿主换实例完成。</p>
      *
-     * @return 启动成功的实例；条件不满足或初始化失败返回 null（静默降级，不影响播放器）。
+     * @return 创建成功的实例；条件不满足返回 null（静默降级，不影响播放器）。
      */
-    public static WatchSync start(Context context, Drive drive) {
+    public static WatchSync create(Context context, Drive drive) {
         try {
             if (drive == null) {
                 Logger.log("WatchSync > 未启用：defaultDrive 为空");
@@ -152,17 +168,14 @@ public class WatchSync {
                 return null;
             }
             WatchSync ws = new WatchSync(context, drive, drive.getUsername(), drive.getSyncPath());
-            ws.initReflection();
+            ws.initReflection();               // 内部解析并锚定 cid
             ws.schedule();
-            // 启动先同步一次，让远端已有记录尽快并入本机
             ws.scheduler.execute(ws::pullAndPush);
-            // 首次同步后初始化 localSnap 基线（记录后续用于生成删除墓碑的本地历史）
-            // 用与“每次同步后更新”同一个函数 refreshLocalSnap()，保证初始与更新一致
             ws.scheduler.execute(ws::refreshLocalSnap);
-            Logger.log("WatchSync > 启动完成");
+            Logger.log("WatchSync > 创建完成：new 实例 user=" + ws.username + " 锚定cid=" + ws.anchorCid);
             return ws;
         } catch (Throwable t) {
-            Logger.log("WatchSync > start failed: " + t);
+            Logger.log("WatchSync > create failed: " + t);
             return null;
         }
     }
@@ -176,109 +189,133 @@ public class WatchSync {
 
         // History 基础方法
         historyGet = historyClass.getMethod("get");
-        historyFindByName = historyClass.getMethod("findByName", String.class);
         historyObjectFrom = historyClass.getMethod("objectFrom", String.class);
-        historySync = historyClass.getMethod("sync", List.class);
         histGetVodName = historyClass.getMethod("getVodName");
-        try {
-            histCanSave = historyClass.getMethod("canSave");
-        } catch (Throwable t) {
-            histCanSave = null;
-        }
-        try {
-            histGetPosition = historyClass.getMethod("getPosition");
-            histGetDuration = historyClass.getMethod("getDuration");
-        } catch (Throwable t) {
-            histGetPosition = null;
-            histGetDuration = null;
-        }
-        // 删除操作：History.delete()（实例方法，按 cid+key 删单条）——用于把墓碑命中的本地记录删掉
-        try {
-            histDel = historyClass.getMethod("delete");
-        } catch (Throwable t) {
-            histDel = null;
-            Logger.log("WatchSync > History.delete() 反射失败，将无法在本地执行墓碑删除: " + t);
-        }
+        // 方案2：本地写入改回走 Room 连接（History.save()），以触发 UI 自动刷新；setCid 用于锚定 cid。
+        // 不用 History.sync()（会强制把 cid 改成当前配置的 cid，破坏锚定）；墓碑删除保留 SQL 直删。
+        histSetCid = historyClass.getMethod("setCid", int.class);
+        historySave = historyClass.getMethod("save");
 
-        // AppDatabase.get().getHistoryDao().findAll()：取本机全量历史（避开 get() 的 LIMIT 60 截断）。
-        // 真机 AppDatabase 可能因混淆/改签名找不到 get()，故做多候选兼容：
-        //   优先试 AppDatabase，再试 Room 生成的 AppDatabase_Impl；
-        //   单例方法先 getMethod 再回退 getDeclaredMethod（连私有/包级也能拿）；
-        //   DAO 方法在实例上按返回类型扫；findAll 在 DAO 实现上找“无参返回 List”的方法。
-        // 任何一步失败都整体降级为 get() 兜底，不影响主流程。
-        appDb = null;
-        daoGetter = null;
-        daoFindAll = null;
-        try {
-            Class<?> dbCls = null;
-            for (String c : new String[]{appPkg + ".db.AppDatabase", appPkg + ".db.AppDatabase_Impl"}) {
-                try {
-                    dbCls = Class.forName(c);
-                    if (dbCls != null) break;
-                } catch (Throwable ignored) {
-                }
-            }
-            if (dbCls != null) {
-                for (String m : new String[]{"get", "getInstance", "getDatabase", "getDb"}) {
-                    Method mm = null;
-                    try {
-                        mm = dbCls.getMethod(m);
-                    } catch (Throwable ignored) {
-                    }
-                    if (mm == null) {
-                        try {
-                            mm = dbCls.getDeclaredMethod(m);
-                            if (mm != null) mm.setAccessible(true);
-                        } catch (Throwable ignored) {
-                        }
-                    }
-                    if (mm != null) {
-                        try {
-                            appDb = mm.invoke(null);
-                            if (appDb != null) break;
-                        } catch (Throwable ignored) {
-                        }
-                    }
-                }
-                if (appDb != null) {
-                    for (Method me : appDb.getClass().getMethods()) {
-                        if (me.getParameterCount() != 0) continue;
-                        if (me.getName().toLowerCase().contains("historydao")) {
-                            daoGetter = me;
-                            break;
-                        }
-                    }
-                    if (daoGetter != null) {
-                        Object dao = daoGetter.invoke(appDb);
-                        if (dao != null) {
-                            for (Method me : dao.getClass().getMethods()) {
-                                if (me.getParameterCount() != 0) continue;
-                                if (!List.class.isAssignableFrom(me.getReturnType())) continue;
-                                String n = me.getName().toLowerCase();
-                                if (n.equals("findall") || n.equals("getall") || n.equals("loadall")) {
-                                    daoFindAll = me;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            Logger.log("WatchSync > AppDatabase.findAll 反射就绪: " + (daoFindAll != null));
-        } catch (Throwable t) {
-            Logger.log("WatchSync > AppDatabase 反射失败，将退化为 get() 兜底: " + t);
-        }
+        // 本机全量历史改为 SQLite 直读（见 localHistoryFull()），不再走 AppDatabase/DAO 反射：
+        // 反编译确认宿主 AppDatabase/DAO 被 R8 彻底混淆（get()→n()、findAll 改名、DAO→q3/*），
+        // 按名反射拿不到 findAll；而 SQLiteDatabase 是系统组件不混淆，直接 SELECT * FROM History 即可，
+        // 不再初始化 appDb/daoGetter/daoFindAll。History bean 的反射仍保留（objectFrom/sync 等沿用）。
 
-        // VodConfig.getCid()：当前播放源 id，用于把多源 findAll 结果过滤到当前源
+        // 候选2（OK影视等魔改壳）：com.fongmi.android.tv.bean.Config.vod() + getId()
+        // id 即为当前配置/源的 cid，homeContent 初始化时此刻可靠，取一次并锚定到 anchorCid。
+        try {
+            Class<?> cfg = Class.forName(appPkg + ".bean.Config");
+            vodConfigVod = cfg.getMethod("vod");
+            try {
+                configGetId = cfg.getMethod("getId");
+            } catch (Throwable t) {
+                configGetId = null;
+            }
+            Logger.log("WatchSync > 候选2 Config.vod() 反射成功: className=" + cfg.getName() + " vod=" + vodConfigVod
+                    + " getId=" + (configGetId != null));
+        } catch (Throwable t) {
+            vodConfigVod = null;
+            configGetId = null;
+            Logger.log("WatchSync > 候选2 Config.vod() 反射失败: " + t);
+        }
+        // 锚定当前源 cid（仅此处读取一次）：Config.vod().getId()
+        anchorCid = currentCid();
+        Logger.log("WatchSync > 锚定 cid=" + anchorCid + " user=" + this.username + "（实例生命周期锁死）");
+        Logger.log("WatchSync > initReflection 完成：本实例 user=" + this.username);
+    }
+
+    /** 解析当前源配置的 cid（多候选反射）：候选1 Config.vod().getId()；候选2 VodConfig.getCid()。取不到返回 -1。静默版，不刷日志（供高频防护探测）。 */
+    private int probeCidQuiet() {
+        String appPkg = appPackage();
+        // 候选1（优先，因为宿主是 OK影视 等魔改壳，日志证实 Config.vod() 反射成功）：Config.vod().getId()
+        if (vodConfigVod != null && configGetId != null) {
+            try {
+                Object cfg = vodConfigVod.invoke(null);
+                if (cfg != null) {
+                    Object v = configGetId.invoke(cfg);
+                    if (v instanceof Number) return ((Number) v).intValue();
+                }
+            } catch (Throwable t) {
+                // 静默
+            }
+        }
+        // 候选2：标准 fongmi api.config.VodConfig.getCid()
         try {
             Class<?> vod = Class.forName(appPkg + ".api.config.VodConfig");
-            vodGetCid = vod.getMethod("getCid");
+            Method m = vod.getMethod("getCid");
+            Object v = m.invoke(null);
+            if (v instanceof Number) return ((Number) v).intValue();
         } catch (Throwable t) {
-            vodGetCid = null;
+            // 静默
         }
-        // 锁定本机播放源 cid：必须放在 initReflection 最末尾、vodGetCid 就绪之后取，
-        // 否则 currentCid() 因 vodGetCid 为 null 返回 -1，导致下面的 guard 永远拦截、同步被关死。
-        this.alistCid = currentCid();
+        return -1;
+    }
+
+    /** 解析当前源配置的 cid（带日志，供初始化锚定时使用）。取不到返回 -1。 */
+    private int currentCid() {
+        String appPkg = appPackage();
+        // 候选1（优先，因为宿主是 OK影视 等魔改壳，日志证实 Config.vod() 反射成功）：Config.vod().getId()
+        if (vodConfigVod != null && configGetId != null) {
+            try {
+                Object cfg = vodConfigVod.invoke(null);
+                if (cfg != null) {
+                    Object v = configGetId.invoke(cfg);
+                    if (v instanceof Number) {
+                        int id = ((Number) v).intValue();
+                        Logger.log("WatchSync > currentCid: 候选1 Config.vod().getId()=" + id);
+                        return id;
+                    }
+                }
+            } catch (Throwable t) {
+                Logger.log("WatchSync > currentCid: 候选1 失败: " + t);
+            }
+        }
+        // 候选2：标准 fongmi api.config.VodConfig.getCid()
+        try {
+            Class<?> vod = Class.forName(appPkg + ".api.config.VodConfig");
+            Method m = vod.getMethod("getCid");
+            Object v = m.invoke(null);
+            if (v instanceof Number) {
+                int id = ((Number) v).intValue();
+                Logger.log("WatchSync > currentCid: 候选2 VodConfig.getCid()=" + id);
+                return id;
+            }
+        } catch (Throwable t) {
+            Logger.log("WatchSync > currentCid: 候选2 失败: " + t);
+        }
+        Logger.log("WatchSync > currentCid: 无可用反射，返回 -1");
+        return -1;
+    }
+
+    /**
+     * cid 防护（fail-closed）：锚定失败(anchorCid<0)，或探测到当前源 cid 已偏离锚定 cid 时，返回 true。
+     * 返回 true 时调用方应<b>整体跳过本轮</b>——不读本地、不读远端、不写远端、不生成墓碑、不动任何基线。
+     * 锚定 cid 恒定不变，currentCid 随切换源变化；偏离即跳过，纯保险丝，零副作用。
+     */
+    private boolean shouldSkipCid(String who) {
+        if (anchorCid < 0) {                         // 锚定失败：fail-closed，绝不动本地/远端
+            if (!cidBlocked) logCidBlock(who, true);
+            return true;
+        }
+        long now = System.currentTimeMillis();
+        if (now - lastProbeAt > CID_PROBE_MS) {      // 静默探测 + 节流，避免高频反射
+            lastProbeAt = now;
+            lastProbeCid = probeCidQuiet();
+        }
+        boolean blocked = (lastProbeCid != anchorCid);
+        if (blocked != cidBlocked) logCidBlock(who, blocked);
+        return blocked;
+    }
+
+    /** 只在 cid 阻塞状态翻转时打一条日志，避免每轮刷屏。 */
+    private boolean logCidBlock(String who, boolean blocked) {
+        cidBlocked = blocked;
+        if (blocked) {
+            Logger.log("WatchSync > " + who + ": cid 已切换/锚定失败（锚定=" + anchorCid + "，当前=" + lastProbeCid + "），本轮跳过，不动本地/远端");
+        } else {
+            Logger.log("WatchSync > " + who + ": cid 恢复一致（锚定=" + anchorCid + "，当前=" + lastProbeCid + "），恢复同步");
+        }
+        return blocked;
     }
 
     /** 由已解析 History 类反推宿主应用包名（截掉 ".bean.History" 后缀）。 */
@@ -324,11 +361,7 @@ public class WatchSync {
      */
     private void pollLocal() {
         try {
-            //如果配置切走了，不执行同步。
-            if (this.alistCid != currentCid()) {
-                return;
-            }
-
+            if (shouldSkipCid("pollLocal")) return;
             List<?> local = localHistoryFull();
             List<String> sig = snapshotOf(local);
             if (!sig.equals(lastSnapshot)) {
@@ -356,8 +389,8 @@ public class WatchSync {
 
     /**
      * 注册周期任务：
-     *   - 本地 3 秒轮询（本机记录变化触发同步）；
-     *   - 定时 30 秒拉取远端（统一走 pullAndPush）。
+     *   - 本地 3 秒轮询；
+     *   - 定时 30 秒拉取远端。
      */
     private void schedule() {
         scheduler.scheduleWithFixedDelay(this::pollLocal, PUSH_POLL_MS, PUSH_POLL_MS, TimeUnit.MILLISECONDS);
@@ -373,17 +406,14 @@ public class WatchSync {
      *   <li>读取远端记录（records + tombstones）；</li>
      *   <li>合并本地与远端（墓碑与记录都按「新者胜」比时间戳）；</li>
      *   <li>把合并结果写回远端（含墓碑，墓碑按 {@link #TOMBSTONE_TTL_MS} 裁剪）；</li>
-     *   <li>合并结果落到本地：墓碑命中的用 historyDel 删除，记录用 historySync 增/改。</li>
+     *   <li>合并结果落到本地：墓碑命中的用 SQL 删除，记录用 SQL 直写 upsert。</li>
      * </ol>
      */
     private void pullAndPush() {
         try {
-            //如果配置切走了，不执行同步。
-            if (this.alistCid != currentCid()) {
-                return;
-            }
-            // ===== 1. 读本地记录，与 localSnap 对比，生成墓碑 =====
-            List<?> local = localHistoryFull();                    // 本机全量
+            if (shouldSkipCid("pullAndPush")) return;
+            // ===== 1. 读本地记录（本实例锚定 cid 分区），与 localSnap 对比，生成墓碑（立即）=====
+            List<?> local = localHistoryFull();                    // 只含锚定 cid 的记录
             Set<String> currentLocal = new HashSet<>();            // 当前本机片名
             for (Object o : local) {
                 String n = vodNameOf(o);
@@ -391,10 +421,12 @@ public class WatchSync {
             }
             long now = System.currentTimeMillis();
             Map<String, Long> myTombs = new HashMap<>();
-            for (String n : localSnap) {                            // 上次同步时本机有、现在没了 → 本机删除
+
+            // 本地上次有、当前没有 → 立即生成墓碑（不再延迟确认）
+            for (String n : localSnap) {
                 if (!currentLocal.contains(n)) {
                     myTombs.put(n, now);
-                    Logger.log("WatchSync > 检测到本机删除，生成墓碑: " + n);
+                    Logger.log("WatchSync > 检测到删除，立即生成墓碑: " + n);
                 }
             }
 
@@ -441,51 +473,64 @@ public class WatchSync {
         }
     }
 
-    /** 把合并结果应用到本地：墓碑命中的删除，records 的用 historySync 增/改。结束后刷新 localSnap 基线。 */
+    /**
+     * 把合并结果应用到本地：
+     *  - 墓碑命中：用 SQL 直删（本锚定 cid 分区内同名记录）；
+     *  - records：改用应用自身的 History.save() 走 Room 连接写入，从而触发界面的自动刷新。
+     * 结束后刷新 localSnap 基线。
+     */
     private void applyLocal(RemoteData merged) {
-        // 5a. 墓碑命中 → 删除本地同名记录（historyDel）
-        if (histDel != null && !merged.tombstones.isEmpty()) {
-            for (String n : merged.tombstones.keySet()) {
-                try {
-                    Object locals = historyFindByName.invoke(null, n);
-                    List<?> list = locals == null ? new ArrayList<>() : (List<?>) locals;
-                    for (Object it : list) {
-                        histDel.invoke(it);
-                    }
-                    if (!list.isEmpty()) {
-                        Logger.log("WatchSync > 墓碑删除本地记录: " + n);
-                    }
-                } catch (Throwable t) {
-                    Logger.log("WatchSync > 墓碑删除本地 err (" + n + "): " + t);
+        // 5a. 墓碑命中 → SQL 直删本锚定 cid 分区内同名记录
+        if (!merged.tombstones.isEmpty()) {
+            SQLiteDatabase db = null;
+            try {
+                File dbf = context.getDatabasePath("tv");
+                if (dbf == null || !dbf.exists()) return;
+                db = SQLiteDatabase.openDatabase(dbf.getPath(), null, SQLiteDatabase.OPEN_READWRITE);
+                for (String n : merged.tombstones.keySet()) {
+                    int del = db.delete("History", "cid = ? AND vodName = ?",
+                            new String[]{String.valueOf(anchorCid), n});
+                    if (del > 0) Logger.log("WatchSync > 墓碑删除本地记录: " + n + "（删 " + del + " 条）");
                 }
+            } catch (Throwable t) {
+                Logger.log("WatchSync > applyLocal(墓碑删除) err: " + t);
+            } finally {
+                if (db != null && db.isOpen()) try { db.close(); } catch (Throwable ignored) {}
             }
         }
-        // 5b. records → 入库（historySync 自带 createTime 新者胜 + 进度保护）
-        List<Object> mine = new ArrayList<>();
+        // 5b. records → 用应用自身 History.save() 写（走 Room 连接，触发 UI 自动刷新）
+        int saved = 0;
         for (int i = 0; i < merged.records.length(); i++) {
             JSONObject wrap = merged.records.optJSONObject(i);
             if (wrap == null) continue;
             JSONObject rec = wrap.optJSONObject("history");
             if (rec == null) continue;
             if (!canSafeMerge(rec)) continue;                        // 进度保护：无进度记录不覆盖本地有进度记录
-            try {
-                Object obj = historyObjectFrom.invoke(null, rec.toString());
-                if (obj != null) {
-                    mine.add(obj);
-                }
-            } catch (Throwable t) {
-                Logger.log("WatchSync > historyObjectFrom err: " + t);
-            }
+            if (saveHistory(rec)) saved++;
         }
-        if (!mine.isEmpty()) {
-            try {
-                historySync.invoke(null, mine);
-            } catch (Throwable t) {
-                Logger.log("WatchSync > historySync err: " + t);
-            }
-        }
+        if (saved > 0) Logger.log("WatchSync > 本地入库 " + saved + " 条（History.save() 走 Room）");
         // 应用完之后的本地库才是真基线 → 统一走 refreshLocalSnap()（与初始化同一函数）
         refreshLocalSnap();
+    }
+
+    /**
+     * 用应用自身的 History.save() 把一条记录写进本地（走 Room 连接 → UI 自动刷新）。
+     * 先用 setCid(anchorCid) 锚定 cid（不用 sync()，避免被强制改成当前配置的 cid）。
+     * 返回是否成功保存。
+     */
+    private boolean saveHistory(JSONObject rec) {
+        try {
+            Object hist = historyObjectFrom.invoke(null, rec.toString());
+            if (hist == null) return false;
+            histSetCid.invoke(hist, anchorCid);                      // 锚定 cid
+            historySave.invoke(hist);                                // 走 Room → 触发 UI 刷新
+            return true;
+        } catch (Throwable t) {
+            Throwable c = t;
+            while (c instanceof java.lang.reflect.InvocationTargetException && c.getCause() != null) c = c.getCause();
+            Logger.log("WatchSync > saveHistory err: " + c);
+            return false;
+        }
     }
 
     /**
@@ -658,50 +703,81 @@ public class WatchSync {
     }
 
     /**
-     * 本机当前播放源(cid)的<b>全量</b>历史对象。
-     * 优先走 AppDatabase.findAll() 反射并过滤当前 cid —— 这才是“本机全集”，
-     * 不会像 get() 那样被 LIMIT 60 截断。
+     * 本机全量历史对象（cid 锚定）：SQLite 直读全表，按记录自带的 cid 过滤到<b>本实例锚定的 cid 分区</b>。
+     * 即 {@code SELECT * FROM History WHERE cid = 锚定cid}；锚定失败(anchorCid<0)时 fail-closed 返回空（入口已由 shouldSkipCid 拦截，此处兜底）。
+     * 天然避开 {@code History.get()} 的 LIMIT 60 截断，也不受 cid 视图漂移影响（过滤条件恒定为锚定 cid）。
      */
     private List<Object> localHistoryFull() {
-        int cid = currentCid();
-        if (appDb != null && daoGetter != null && daoFindAll != null) {
+        List<Object> out = new ArrayList<>();
+        SQLiteDatabase db = null;
+        Cursor cur = null;
+        try {
+            File dbf = context.getDatabasePath("tv");
+            if (dbf == null || !dbf.exists()) {
+                Logger.log("WatchSync > SQLite 直读失败：库文件不存在 " + (dbf == null ? "null" : dbf.getPath()));
+                return localHistoryFallback();
+            }
+            // 收集 History bean 里 boolean 类型的字段：Room 把 boolean 存成 INTEGER(0/1)，
+            // 喂给 Gson objectFrom 时必须转成 true/false，否则数字 token 反序列化到 boolean 会抛 JsonSyntaxException。
+            Set<String> boolFields = new java.util.HashSet<>();
             try {
-                Object dao = daoGetter.invoke(appDb);
-                if (dao != null) {
-                    Object all = daoFindAll.invoke(dao);
-                    if (all instanceof List) {
-                        List<Object> out = new ArrayList<>();
-                        for (Object o : (List<?>) all) {
-                            if (o == null) continue;
-                            // 过滤到当前播放源，避免把其他源的记录误当作本源记录
-                            if (cid >= 0) {
-                                try {
-                                    JSONObject j = historyToJson(o);
-                                    if (j == null || j.optInt("cid", -1) != cid) continue;
-                                } catch (Throwable t) {
-                                    continue;
-                                }
+                for (Field f : historyClass.getDeclaredFields()) {
+                    if (f.getType() == boolean.class) boolFields.add(f.getName());
+                }
+                Logger.log("WatchSync > SQLite 直读 boolean 字段: " + boolFields);
+            } catch (Throwable t) {
+                Logger.log("WatchSync > SQLite 直读 反射 boolean 字段失败: " + t);
+            }
+            db = SQLiteDatabase.openDatabase(dbf.getPath(), null, SQLiteDatabase.OPEN_READONLY);
+            // 全量读表，按记录自带的 cid 过滤到本实例锚定的 cid 分区；anchorCid<0（锚定失败）fail-closed 返回空
+            if (anchorCid >= 0) {
+                cur = db.rawQuery("SELECT * FROM History WHERE cid = ?", new String[]{String.valueOf(anchorCid)});
+            } else {
+                Logger.log("WatchSync > localHistoryFull: 锚定失败(anchorCid<0) fail-closed 返回空，不同步");
+                return out;
+            }
+            String[] cols = cur.getColumnNames();
+            while (cur.moveToNext()) {
+                JSONObject j = new JSONObject();
+                for (String col : cols) {
+                    int idx = cur.getColumnIndex(col);
+                    if (idx < 0) continue;
+                    if (cur.isNull(idx)) continue;
+                    try {
+                        int t = cur.getType(idx);
+                        if (t == Cursor.FIELD_TYPE_STRING) {
+                            j.put(col, cur.getString(idx));
+                        } else if (t == Cursor.FIELD_TYPE_INTEGER) {
+                            if (boolFields.contains(col)) {
+                                j.put(col, cur.getInt(idx) != 0);   // 真布尔 true/false
+                            } else {
+                                j.put(col, cur.getLong(idx));
                             }
-                            out.add(o);
+                        } else if (t == Cursor.FIELD_TYPE_FLOAT) {
+                            j.put(col, cur.getDouble(idx));
+                        } else if (t == Cursor.FIELD_TYPE_BLOB) {
+                            j.put(col, android.util.Base64.encodeToString(cur.getBlob(idx), android.util.Base64.NO_WRAP));
                         }
-                        return out;
+                    } catch (Throwable ignored) {
                     }
                 }
-            } catch (Throwable t) {
-                Logger.log("WatchSync > findAll 失败，退化 get() 兜底: " + t);
+                try {
+                    Object obj = historyObjectFrom.invoke(null, j.toString());
+                    if (obj != null) out.add(obj);
+                } catch (Throwable t) {
+                    Throwable c = t;
+                    while (c instanceof java.lang.reflect.InvocationTargetException && c.getCause() != null) c = c.getCause();
+                    Logger.log("WatchSync > SQLite 直读 objectFrom 失败，跳过一行: " + c);
+                }
             }
-        }
-        return localHistoryFallback();
-    }
-
-    /** 当前播放源 id；反射不可用返回 -1（表示不过滤）。 */
-    private int currentCid() {
-        if (vodGetCid == null) return -1;
-        try {
-            Object v = vodGetCid.invoke(null);
-            return v instanceof Number ? ((Number) v).intValue() : -1;
+            Logger.log("WatchSync > SQLite 直读 History 全量：" + out.size() + " 条");
+            return out;
         } catch (Throwable t) {
-            return -1;
+            Logger.log("WatchSync > SQLite 直读失败，退化 get() 兑底: " + t);
+            return localHistoryFallback();
+        } finally {
+            if (cur != null) try { cur.close(); } catch (Throwable ignored) {}
+            if (db != null && db.isOpen()) try { db.close(); } catch (Throwable ignored) {}
         }
     }
 
@@ -745,41 +821,36 @@ public class WatchSync {
 
     // ---------------- 进度保护 ----------------
 
-    /** 判断远端记录是否“有进度可保存”，用于进度保护。 */
-    private boolean hasProgress(Object hist) {
-        try {
-            if (histCanSave != null) return (Boolean) histCanSave.invoke(hist);
-            if (histGetPosition != null && histGetDuration != null) {
-                long pos = ((Number) histGetPosition.invoke(hist)).longValue();
-                long dur = ((Number) histGetDuration.invoke(hist)).longValue();
-                return pos >= 0 && dur > 0;
-            }
-            return true;
-        } catch (Throwable t) {
-            return true;
-        }
-    }
-
     /**
-     * 入库前的安全合并判断：
-     * 远端记录无进度（如仅点开未播放）时，不允许覆盖本机“已有进度”的同名记录，避免进度倒退。
+     * 入库前的安全合并判断（纯 JSON + SQLite，不再走 bean 反射）：
+     * 远端记录无进度（position<0 或 duration<=0，如仅点开未播放）时，
+     * 不允许覆盖本机“已有进度”的同名记录，避免进度倒退。
      */
     private boolean canSafeMerge(JSONObject rec) {
         try {
-            Object hist = historyObjectFrom.invoke(null, rec.toString());
-            if (hist == null) return true;
-            boolean remoteCanSave = hasProgress(hist);
-            if (remoteCanSave) return true;
-            String vodName = (String) histGetVodName.invoke(hist);
-            Object locals = historyFindByName.invoke(null, vodName);
-            if (locals == null) return true;
-            for (Object it : (List<?>) locals) {
-                if (hasProgress(it)) {
-                    Logger.log("WatchSync > 进度保护：无进度记录不覆盖本地有进度记录 name=" + vodName);
-                    return false;
+            long pos = rec.optLong("position", -1L);
+            long dur = rec.optLong("duration", 0L);
+            if (pos >= 0 && dur > 0) return true;                    // 远端有进度 → 可写
+            String vodName = rec.optString("vodName", "");
+            if (vodName.isEmpty()) return true;
+            SQLiteDatabase db = null;
+            try {
+                File dbf = context.getDatabasePath("tv");
+                if (dbf == null || !dbf.exists()) return true;
+                db = SQLiteDatabase.openDatabase(dbf.getPath(), null, SQLiteDatabase.OPEN_READONLY);
+                try (Cursor c = db.rawQuery("SELECT position, duration FROM History WHERE cid = ? AND vodName = ?",
+                        new String[]{String.valueOf(anchorCid), vodName})) {
+                    while (c.moveToNext()) {
+                        if (c.getLong(0) >= 0 && c.getLong(1) > 0) {
+                            Logger.log("WatchSync > 进度保护：无进度记录不覆盖本地有进度记录 name=" + vodName);
+                            return false;
+                        }
+                    }
                 }
+                return true;
+            } finally {
+                if (db != null && db.isOpen()) try { db.close(); } catch (Throwable ignored) {}
             }
-            return true;
         } catch (Throwable t) {
             return true;
         }
@@ -787,9 +858,11 @@ public class WatchSync {
 
     // ---------------- 服务器文件读写 ----------------
 
+
     /** 读取远端同步文件全文；读取失败返回 null（调用方自行区分空文件与失败）。 */
     private String readRemote() {
         try {
+            if (shouldSkipCid("readRemote")) return null;
             String out = drive.exec("cat \"" + syncPath + "\"");
             if (out == null) {
                 Logger.log("WatchSync > readRemote: 远端返回 null");
@@ -808,6 +881,7 @@ public class WatchSync {
      */
     private void writeRemote(String json) {
         try {
+            if (shouldSkipCid("writeRemote")) return;
             String b64 = android.util.Base64.encodeToString(json.getBytes(StandardCharsets.UTF_8), android.util.Base64.NO_WRAP);
             String cmd = "printf '%s' '" + b64 + "' | base64 -d > \"" + syncPath + ".tmp\" && mv \"" + syncPath + ".tmp\" \"" + syncPath + "\"";
             String res = drive.exec(cmd);


### PR DESCRIPTION
完善 AListSh 的观看记录多端同步（WatchSync）：

**问题**
- 原实现把设备本地、随配置切换而变的自增 cid 当作同步隔离维度，两次拍库对比（其中一次是 LIMIT-60 非全集）自动判删，cid 一变就全量误判删除，写回墓碑传染所有设备。
- dao.findAll 反射在混淆的壳里拿不到，退化成 History.get() 的 LIMIT-60 截断，把"自然淘汰"误判成删除。

**改动**
1. **锚定模型**：每个 AListSh 实例自持一个 WatchSync（非静态单例），homeContent 首次进入懒创建并锚定 cid+username；切配置=换实例=换 sync。
2. **cid 不可靠，弃用其作隔离维度**：改按 username 隔离远端文件（watch.<user>.txt），本地历史 SQLite 直读（避开 LIMIT-60），并按锚定 cid 过滤分区。
3. **防误删**：cid 防护 fail-closed——锚定失败或当前 cid 已切换时整体跳过本轮，不读不写、不生成墓碑、不动基线（纯保险丝，零副作用）。
4. **墓碑按 createTime 新者胜**合并（LWW-register），带 TTL 裁剪防无限累积。
5. **兼容性**：本地读写均用 SQLite 直连（系统组件不混淆），可兼容原版 FongMi 与各魔改壳（如 player 等 fork 新增 NOT NULL 列通过动态读表结构自动适配）。

涉及：`AListSh.java`、`WatchSync.java`（仅源码，无产物）。
