### PR TITLE
fix: historyToJson序列化时跳过cid字段，远端不存cid避免跨设备写放大

### DIFF
--- a/app/src/main/java/com/github/catvod/spider/WatchSync.java
+++ b/app/src/main/java/com/github/catvod/spider/WatchSync.java
@@ -842,7 +842,9 @@ public class WatchSync {
         try {
             String str = o.toString();
             if (str != null && str.trim().startsWith("{")) {
-                return new JSONObject(str);
+                JSONObject j = new JSONObject(str);
+                j.remove("cid");                         // 远端不存 cid：跨设备无意义，避免写放大
+                return j;
             }
         } catch (Throwable ignored) {
         }
@@ -850,6 +852,7 @@ public class WatchSync {
             JSONObject json = new JSONObject();
             Field[] fields = historyClass.getDeclaredFields();
             for (Field f : fields) {
+                if ("cid".equals(f.getName())) continue;   // 跳过 cid，远端不存
                 f.setAccessible(true);
                 Object val = f.get(o);
                 if (val != null) json.put(f.getName(), val);


### PR DESCRIPTION
## 问题

WatchSync 跨设备同步时，historyToJson() 把 History 所有字段（含 cid）都序列化写入远端文件。cid 是本地源标识，跨设备无意义。导致设备间互相覆盖对方的 cid，json.equals(raw) 每轮判定内容变了，触发无意义的远端重写（写放大无限循环）。

## 修复

在 historyToJson() 序列化时跳过 cid 字段（o.toString 路径 j.remove + 反射路径 continue）。远端文件只存播放内容，不存源标识，从根本上消除跨设备 cid 冲突。