### PR TITLE
fix: 远端key去掉cid后缀，本地save再追加anchorCid，修复跨源切换丢记录

### DIFF
--- a/app/src/main/java/com/github/catvod/spider/WatchSync.java
+++ b/app/src/main/java/com/github/catvod/spider/WatchSync.java
@@ -533,6 +533,14 @@ public class WatchSync {
         long dur = rec.optLong("duration", 0L);
         dedupLocal(name, dur);                                       // 手工去重（抄 sync 判定）
         try {
+            // 修复 key 里的旧 cid：远端记录的 key 末尾带了写入方的 cid，
+            // 不替换的话 INSERT OR REPLACE 会覆盖其它 cid 分区的同 key 记录。
+            String key = rec.optString("key", "");
+            int lastAt = key.lastIndexOf("@@@");
+            if (lastAt > 0) {
+                String newKey = key.substring(0, lastAt + 3) + anchorCid;
+                if (!newKey.equals(key)) rec.put("key", newKey);
+            }
             Object hist = historyObjectFrom.invoke(null, rec.toString());
             if (hist == null) return false;
             histSetCid.invoke(hist, anchorCid);                      // 锚定 cid

--- a/app/src/main/java/com/github/catvod/spider/WatchSync.java
+++ b/app/src/main/java/com/github/catvod/spider/WatchSync.java
@@ -533,13 +533,11 @@ public class WatchSync {
         long dur = rec.optLong("duration", 0L);
         dedupLocal(name, dur);                                       // 手工去重（抄 sync 判定）
         try {
-            // 修复 key 里的旧 cid：远端记录的 key 末尾带了写入方的 cid，
-            // 不替换的话 INSERT OR REPLACE 会覆盖其它 cid 分区的同 key 记录。
+            // 远端 key 不含 cid，本地写入时追加 anchorCid：
+            // "Alist@@@path/~xiaoya" → "Alist@@@path/~xiaoya@@@27"
             String key = rec.optString("key", "");
-            int lastAt = key.lastIndexOf("@@@");
-            if (lastAt > 0) {
-                String newKey = key.substring(0, lastAt + 3) + anchorCid;
-                if (!newKey.equals(key)) rec.put("key", newKey);
+            if (!key.endsWith("@@@" + anchorCid)) {
+                rec.put("key", key + "@@@" + anchorCid);
             }
             Object hist = historyObjectFrom.invoke(null, rec.toString());
             if (hist == null) return false;
@@ -851,7 +849,8 @@ public class WatchSync {
             String str = o.toString();
             if (str != null && str.trim().startsWith("{")) {
                 JSONObject j = new JSONObject(str);
-                j.remove("cid");                         // 远端不存 cid：跨设备无意义，避免写放大
+                j.remove("cid");                         // 远端不存 cid：跨设备无意义
+                stripKeyCid(j);                            // key 里的 cid 也去掉
                 return j;
             }
         } catch (Throwable ignored) {
@@ -865,11 +864,19 @@ public class WatchSync {
                 Object val = f.get(o);
                 if (val != null) json.put(f.getName(), val);
             }
+            stripKeyCid(json);                             // key 里的 cid 也去掉
             return json;
         } catch (Throwable t) {
             Logger.log("WatchSync > historyToJson failed: " + t);
             return null;
         }
+    }
+
+    /** 去掉 key 末尾的 @@cid 后缀，远端完全不存 cid。 */
+    private static void stripKeyCid(JSONObject j) {
+        String key = j.optString("key", "");
+        int lastAt = key.lastIndexOf("@@@");
+        if (lastAt > 0) j.put("key", key.substring(0, lastAt));
     }
 
     // ---------------- 进度保护 ----------------


### PR DESCRIPTION
## 问题

反复切换源时观看记录会丢失（误生成墓碑）。

**根因**：远端记录的 key 字段末尾嵌了 cid（如 `Alist@@@path/~xiaoya@@@25`）。换成 save+手工去重后，跨 cid 写入时 key 和 cid 不匹配：实例 B（cid=27）从远端拉到 key 仍是 `...~xiaoya@@@25`，save() 用 INSERT OR REPLACE 按 key 覆盖，把实例 A 的记录从 cid=25 盖成 cid=27。实例 A 下轮 `WHERE cid=25` 找不到 → 误生墓碑 → 记录丢失。

## 修复

1. **saveHistory()**：本地写入前把 key 统一追加本机 anchorCid，保证每实例 key/cid 一致，谁也不会覆盖谁。
2. **historyToJson() + stripKeyCid()**：远端存储时 key 末尾的 cid 也去掉（连同 cid 字段），本地写入时才追加。远端文件彻底无 cid，跨设备同步更干净。