### PR TITLE
fix: saveHistory兼容老格式远端key，先stripKeyCid剥离旧cid再追加anchorCid

### DIFF
--- a/app/src/main/java/com/github/catvod/spider/WatchSync.java
+++ b/app/src/main/java/com/github/catvod/spider/WatchSync.java
@@ -533,6 +533,14 @@ public class WatchSync {
         long dur = rec.optLong("duration", 0L);
         dedupLocal(name, dur);                                       // 手工去重（抄 sync 判定）
         try {
+            // 修复 key 里的旧 cid：远端记录的 key 末尾带了写入方的 cid，
+            // 不替换的话 INSERT OR REPLACE 会覆盖其它 cid 分区的同 key 记录。
+            String key = rec.optString("key", "");
+            int lastAt = key.lastIndexOf("@@@");
+            if (lastAt > 0) {
+                String newKey = key.substring(0, lastAt + 3) + anchorCid;
+                if (!newKey.equals(key)) rec.put("key", newKey);
+            }
             Object hist = historyObjectFrom.invoke(null, rec.toString());
             if (hist == null) return false;
             histSetCid.invoke(hist, anchorCid);                      // 锚定 cid

--- a/app/src/main/java/com/github/catvod/spider/WatchSync.java
+++ b/app/src/main/java/com/github/catvod/spider/WatchSync.java
@@ -533,13 +533,11 @@ public class WatchSync {
         long dur = rec.optLong("duration", 0L);
         dedupLocal(name, dur);                                       // 手工去重（抄 sync 判定）
         try {
-            // 修复 key 里的旧 cid：远端记录的 key 末尾带了写入方的 cid，
-            // 不替换的话 INSERT OR REPLACE 会覆盖其它 cid 分区的同 key 记录。
+            // 远端 key 不含 cid，本地写入时追加 anchorCid：
+            // "Alist@@@path/~xiaoya" → "Alist@@@path/~xiaoya@@@27"
             String key = rec.optString("key", "");
-            int lastAt = key.lastIndexOf("@@@");
-            if (lastAt > 0) {
-                String newKey = key.substring(0, lastAt + 3) + anchorCid;
-                if (!newKey.equals(key)) rec.put("key", newKey);
+            if (!key.endsWith("@@@" + anchorCid)) {
+                rec.put("key", key + "@@@" + anchorCid);
             }
             Object hist = historyObjectFrom.invoke(null, rec.toString());
             if (hist == null) return false;
@@ -851,7 +849,8 @@ public class WatchSync {
             String str = o.toString();
             if (str != null && str.trim().startsWith("{")) {
                 JSONObject j = new JSONObject(str);
-                j.remove("cid");                         // 远端不存 cid：跨设备无意义，避免写放大
+                j.remove("cid");                         // 远端不存 cid：跨设备无意义
+                stripKeyCid(j);                            // key 里的 cid 也去掉
                 return j;
             }
         } catch (Throwable ignored) {
@@ -865,11 +864,19 @@ public class WatchSync {
                 Object val = f.get(o);
                 if (val != null) json.put(f.getName(), val);
             }
+            stripKeyCid(json);                             // key 里的 cid 也去掉
             return json;
         } catch (Throwable t) {
             Logger.log("WatchSync > historyToJson failed: " + t);
             return null;
         }
+    }
+
+    /** 去掉 key 末尾的 @@cid 后缀，远端完全不存 cid。 */
+    private static void stripKeyCid(JSONObject j) {
+        String key = j.optString("key", "");
+        int lastAt = key.lastIndexOf("@@@");
+        if (lastAt > 0) j.put("key", key.substring(0, lastAt));
     }
 
     // ---------------- 进度保护 ----------------

--- a/app/src/main/java/com/github/catvod/spider/WatchSync.java
+++ b/app/src/main/java/com/github/catvod/spider/WatchSync.java
@@ -533,8 +533,10 @@ public class WatchSync {
         long dur = rec.optLong("duration", 0L);
         dedupLocal(name, dur);                                       // 手工去重（抄 sync 判定）
         try {
-            // 远端 key 不含 cid，本地写入时追加 anchorCid：
-            // "Alist@@@path/~xiaoya" → "Alist@@@path/~xiaoya@@@27"
+            // 兼容新旧格式：先剥离 key 尾部可能存在的旧 cid（老格式带 @@cid，新格式不带），
+            // 再追加本机 anchorCid。
+            // "Alist@@@path/~xiaoya@@@25" → stripKeyCid → "Alist@@@path/~xiaoya" → "Alist@@@path/~xiaoya@@@27"
+            stripKeyCid(rec);
             String key = rec.optString("key", "");
             if (!key.endsWith("@@@" + anchorCid)) {
                 rec.put("key", key + "@@@" + anchorCid);


### PR DESCRIPTION
## 问题

上一版 saveHistory 只处理"远端 key 无 cid"的新格式。若远端文件是**老格式**（key 末尾带 cid，如 `Alist@@@path/~xiaoya@@@25`），直接追加本机 anchorCid 会变成 `...~xiaoya@@@25@@@27`（双 cid，错误），导致 key 匹配失败、记录错乱。

## 修复

saveHistory 写入前先调用 stripKeyCid() 剥离 key 尾部可能存在的旧 cid，再追加本机 anchorCid，新旧格式通吃：

- 老格式 `...~xiaoya@@@25` → 剥离 → `...~xiaoya` → 追加 `@@@27`
- 新格式 `...~xiaoya` → 直接追加 `@@@27`