### PR TITLE
fix: saveHistory兼容老格式远端key，先stripKeyCid剥离旧cid再追加anchorCid

### DIFF
--- a/app/src/main/java/com/github/catvod/spider/WatchSync.java
+++ b/app/src/main/java/com/github/catvod/spider/WatchSync.java
@@ -533,8 +533,10 @@ public class WatchSync {
         long dur = rec.optLong("duration", 0L);
         dedupLocal(name, dur);                                       // 手工去重（抄 sync 判定）
         try {
-            // 远端 key 不含 cid，本地写入时追加 anchorCid：
-            // "Alist@@@path/~xiaoya" → "Alist@@@path/~xiaoya@@@27"
+            // 兼容新旧格式：先剥离 key 尾部可能存在的旧 cid（老格式带 @@cid，新格式不带），
+            // 再追加本机 anchorCid。
+            // "Alist@@@path/~xiaoya@@@25" → stripKeyCid → "Alist@@@path/~xiaoya" → "Alist@@@path/~xiaoya@@@27"
+            stripKeyCid(rec);
             String key = rec.optString("key", "");
             if (!key.endsWith("@@@" + anchorCid)) {
                 rec.put("key", key + "@@@" + anchorCid);


### PR DESCRIPTION
## 问题

上一版 saveHistory 只处理"远端 key 无 cid"的新格式。若远端文件是**老格式**（key 末尾带 cid，如 `Alist@@@path/~xiaoya@@@25`），直接追加本机 anchorCid 会变成 `...~xiaoya@@@25@@@27`（双 cid，错误），导致 key 匹配失败、记录错乱。

## 修复

saveHistory 写入前先调用 stripKeyCid() 剥离 key 尾部可能存在的旧 cid，再追加本机 anchorCid，新旧格式通吃：

- 老格式 `...~xiaoya@@@25` → 剥离 → `...~xiaoya` → 追加 `@@@27`
- 新格式 `...~xiaoya` → 直接追加 `@@@27`