### PR TITLE
fix: stripKeyCid按段数≥3才剥末段，避免把2段式key的纯数字路径段误删

### DIFF
--- a/app/src/main/java/com/github/catvod/spider/WatchSync.java
+++ b/app/src/main/java/com/github/catvod/spider/WatchSync.java
@@ -913,13 +913,20 @@ public class WatchSync {
         }
     }
 
-    /** 去掉 key 末尾的 @@cid 后缀（仅当 key 以 @@@加纯数字结尾时），远端不存 cid。 */
+    /** 去掉 key 末尾的 @@cid 后缀（远端不存 cid）。
+     * 判据：只有 key 是 \"A@@@B@@@Cid\" 这种 ≥3 段式、且末段是纯数字时才剥掉这最后一小段；
+     * 否则（如 2 段式的路径段本身就以数字结尾）原样不动，避免误删路径段。 */
     private static void stripKeyCid(JSONObject j) {
         try {
             String key = j.optString("key", "");
-            if (key.matches(".*@@@\\d+$")) {
-                j.put("key", key.replaceFirst("@@@\\d+$", ""));
-            }
+            if (key.isEmpty()) return;
+            int last = key.lastIndexOf("@@@");
+            if (last <= 0) return;                    // 找不到分隔符 → 无 cid，不动
+            String tail = key.substring(last + 3);     // 末段
+            if (!tail.matches("\\d+")) return;        // 末段非纯数字 → 不是 cid，不动
+            // 末段是纯数字，且前面还出现过至少一个 @@@（即总段数 ≥3）→ 末段才是 cid，剥掉它
+            if (key.lastIndexOf("@@@", last - 1) < 0) return;   // 只有一段 @@@（2 段式）→ 不动
+            j.put("key", key.substring(0, last));
         } catch (org.json.JSONException ignored) {
         }
     }


### PR DESCRIPTION
## 修复：stripKeyCid 按段数判断，避免把 2 段式 key 的纯数字路径段误删

### 问题
原正则 `.*@@@\d+$` 只判断"尾部是数字"就剥，无法区分尾段到底是 **cid** 还是**路径本身是数字**：
- 3 段式 `源@@@路径@@@25` → 剥 cid 正确 ✅
- 2 段式 `源@@@123`（路径就是数字、没有 cid）→ 被误删成 `源` ❌

### 修复
只有 key 是 `A@@@B@@@Cid` 这种 **≥3 段式、且末段是纯数字** 时才剥掉这最后一小段；否则（2 段式、或末段非数字）原样不动。
- 只剥最后一小段，绝不碰前面的数字段
- 是否剥由"段数是否 ≥3"决定，而不是"是不是数字"

### 验证
六种 case（3段剥尾 / 2段数字路径 / 3段段2数字 / 2段普通 / 末段非数字）单测全过，javac 编译 OK。
