### PR TITLE
feat(login): 登录对话框/失败提示重构合集

### DIFF
--- a/app/src/main/java/com/github/catvod/bean/alist/LoginDlg.java
+++ b/app/src/main/java/com/github/catvod/bean/alist/LoginDlg.java
@@ -5,82 +5,121 @@ import com.github.catvod.spider.Logger;
 
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.DialogInterface;
+import android.text.InputType;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
-import android.widget.Toast;
+import android.widget.LinearLayout;
+
+import java.util.concurrent.CountDownLatch;
+
 
 public class LoginDlg {
 
-    private static final Object lock = new Object(); // 用于线程同步的锁
-    private static String userInput = ""; // 用户输入
+
 
     /**
-     * 显示登录对话框，并阻塞后台线程直到对话框关闭
+     * 显示单输入框对话框（兼容旧的单字段场景），阻塞后台线程直到对话框关闭或超时。
      *
      * @param hint 输入框的提示文本
-     * @return 用户输入的内容（如果用户取消输入，返回空字符串）
+     * @return 用户输入的内容（取消/超时返回空字符串）
      */
     public static String showLoginDlg(String hint) {
-        userInput = "";
-        synchronized (lock) {
-            try {
-                Activity activity = Init.getActivity();
-                if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
-                    return ""; // 如果 Activity 无效，直接返回
-                }
+        String[] result = showLoginDlg(hint, null);
+        return result == null ? "" : result[0];
+    }
 
-                // 在主线程显示对话框
-                Init.run(() -> {
-                    Logger.log("准备显示对话框");
-                    // 创建一个 EditText 用于用户输入
-                    final EditText input = new EditText(activity);
-                    input.setHint(hint);
+    /**
+     * 显示"用户名 + 密码"双输入框登录对话框，一次弹窗收集两个字段，阻塞后台线程直到对话框关闭或超时。
+     * 密码框自动掩码；按返回键/取消/超时都会正常唤醒，不会造成线程卡死。
+     *
+     * @param usernameHint 用户名输入框提示
+     * @param passwordHint 密码输入框提示（null 表示只需要单输入框）
+     * @return {@code [0]=用户名, [1]=密码}；取消/超时/Activity无效 返回 {@code null}（调用方可据此中断登录）
+     */
+    public static String[] showLoginDlg(final String usernameHint, final String passwordHint) {
+        return showLoginDlg(null, usernameHint, passwordHint);
+    }
 
-                    // 创建 AlertDialog
+    /**
+     * 显示"用户名 + 密码"双输入框登录对话框，一次弹窗收集两个字段，阻塞后台线程直到对话框关闭或超时。
+     * 密码框自动掩码；按返回键/取消/超时都会正常唤醒，不会造成线程卡死。
+     *
+     * @param server       正在登录的服务器地址（显示在标题，多服务器时区分；可为 null）
+     * @param usernameHint 用户名输入框提示
+     * @param passwordHint 密码输入框提示（null 表示只需要单输入框）
+     * @return {@code [0]=用户名, [1]=密码}；取消/超时/Activity无效 返回 {@code null}（调用方可据此中断登录）
+     */
+    public static String[] showLoginDlg(final String server, final String usernameHint, final String passwordHint) {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final boolean[] confirmed = { false }; // 仅“确定”置 true；取消/返回键/超时保持 false
+        final String[] result = { "", "" };
+        try {
+            Activity activity = Init.getActivity();
+            if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
+                return null; // Activity 无效，不阻塞
+            }
+
+            // 在主线程显示对话框，延迟一步等待 Activity 就绪
+            Init.run(() -> {
+                try {
+                    final EditText userInput = new EditText(activity);
+                    userInput.setHint(usernameHint);
+                    userInput.setSingleLine(true);
+
+                    final LinearLayout layout = new LinearLayout(activity);
+                    layout.setOrientation(LinearLayout.VERTICAL);
+                    layout.setPadding(60, 30, 60, 0);
+                    layout.addView(userInput);
+
+                    final EditText passwordInput;
+                    if (passwordHint != null) {
+                        passwordInput = new EditText(activity);
+                        passwordInput.setHint(passwordHint);
+                        passwordInput.setSingleLine(true);
+                        passwordInput.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD); // 密码掩码
+                        layout.addView(passwordInput);
+                    } else {
+                        passwordInput = null;
+                    }
+
+                    String title = (server == null || server.isEmpty()) ? "登录设置" : ("登录 - " + server);
                     AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-                    builder.setTitle("输入对话框")
-                            .setMessage("请填写以下信息：")
-                            .setIcon(android.R.drawable.ic_dialog_info) // 设置图标
-                            .setView(input) // 添加输入框
-                            .setPositiveButton("确定", new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    Logger.log("onClick1:" + userInput);
-                                    synchronized (lock) {
-                                        userInput = input.getText().toString();
-                                        Logger.log("userInput:" + userInput);
-                                        lock.notifyAll(); // 唤醒阻塞的线程
-                                    }
-                                    Logger.log("onClick2:" + userInput);
+                    builder.setTitle(title)
+                            .setMessage(passwordHint != null ? "请填写用户名与密码" : "请填写所需信息")
+                            .setIcon(android.R.drawable.ic_dialog_info)
+                            .setView(layout)
+                            .setPositiveButton("确定", (dialog, which) -> {
+                                result[0] = userInput.getText().toString();
+                                if (passwordInput != null) {
+                                    result[1] = passwordInput.getText().toString();
                                 }
+                                confirmed[0] = true;
+                                latch.countDown();
                             })
-                            .setNegativeButton("取消", new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    Logger.log("onClick3:" + userInput);
-                                    synchronized (lock) {
-                                        userInput = ""; // 清空用户输入
-                                        lock.notifyAll(); // 唤醒阻塞的线程
-                                    }
-                                }
-                            });
+                            .setNegativeButton("取消", (dialog, which) -> latch.countDown())
+                            .setOnCancelListener(dialog -> latch.countDown()); // 按返回键也会唤醒，杜绝卡死
 
-                    // 显示对话框
                     AlertDialog dialog = builder.create();
                     dialog.show();
-                    Logger.log("显示对话框完成");
-                }, 500);
+                    // 自动弹出软键盘
+                    userInput.requestFocus();
+                    InputMethodManager imm = (InputMethodManager) activity.getSystemService(Activity.INPUT_METHOD_SERVICE);
+                    if (imm != null) {
+                        imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
+                    }
+                } catch (Exception e) {
+                    Logger.log("登录对话框异常:" + e);
+                    latch.countDown();
+                }
+            }, 500);
 
-                // 阻塞后台线程，直到对话框关闭
-                lock.wait(); // 等待对话框关闭
-
-                Logger.log("正确获取输出：" + userInput);
-                return userInput; // 返回用户输入
-            } catch (Exception e) {
-                e.printStackTrace(); // 记录异常日志
-                Logger.log("发生异常");
-                return ""; // 发生异常时返回空字符串
-            }
+            // 阻塞后台线程，直到对话框关闭（不超时，一直等用户操作; 返回键/取消已由 onCancel countDown 唤醒）
+            latch.await();
+        } catch (Exception e) {
+            Logger.log("登录对话框异常:" + e);
+            return null;
         }
+        // 仅“确定”返回输入；取消/返回键/超时都返回 null（中断登录）
+        return confirmed[0] ? result : null;
     }
 }

--- a/app/src/main/java/com/github/catvod/spider/AListSh.java
+++ b/app/src/main/java/com/github/catvod/spider/AListSh.java
@@ -19,6 +19,7 @@ import com.github.catvod.crawler.Spider;
 import com.github.catvod.net.OkHttp;
 import com.github.catvod.utils.Util;
 import com.github.catvod.utils.Image;
+import com.github.catvod.utils.Notify;
 import com.github.catvod.bean.alist.Pager;
 import org.json.JSONObject;
 import java.util.ArrayList;
@@ -70,6 +71,10 @@ public class AListSh extends Spider {
     private WatchSync watchSync;
 
     private Context mContext;
+
+    // A+C: 按服务器缓存登录 token, 同服务器缓存命中即短路去重, 避免启动阶段多线程重复登录
+    // token 有效期极长, 不做 TTL; 仅在服务端实际返回 401/403(失效) 时清缓存重新登录
+    private final Map<String, String> serverTokenCache = new HashMap<>();
 
     private String getRootCmd(Drive drive) {
         return drive.getCombinedMode() ? "{ cat index.combined.txt;echo ''; }" : "{ cat index.video.txt;echo ''; }";
@@ -462,36 +467,74 @@ public class AListSh extends Spider {
         } catch (Exception e) {
             Logger.log("post" + e);
         }
-        if (retry && (code == 401 || code == 403) && login(drive)) {
-            return post(drive, url, param, false);
+        if (retry && (code == 401 || code == 403)) {
+            if (login(drive)) {
+                String retryResp = post(drive, url, param, false);
+                // token 复用后仍 401/403 → 缓存 token 已失效, 清缓存供下次重新登录
+                try {
+                    int rc = new JSONObject(retryResp).getInt("code");
+                    if (rc == 401 || rc == 403) {
+                        serverTokenCache.remove(drive.getServer());
+                    }
+                } catch (Exception ignored) {
+                }
+                return retryResp;
+            }
         }
         return response;
     }
 
     private synchronized boolean login(Drive drive) {
+        // A+C: 同一服务器已有缓存 token → 直接复用, 不再重复登录/二次验证; 无 TTL, 失效由服务端 401/403 触发
+        String server = drive.getServer();
+        String cached = serverTokenCache.get(server);
+        if (cached != null && !cached.isEmpty()) {
+            drive.setToken(cached);
+            for (Drive d : drives) {
+                if (d.getServer().equals(server)) {
+                    d.setToken(cached);
+                }
+            }
+            return true;
+        }
         boolean result = loginByConfig(drive) || loginByFile(drive) || loginByUser(drive);
         if (!result) {
             return false;
         }
         //即便登陆成功也要再次验证，比如guest登陆成功，但是结果还是401
         int code = 200;
+        String errMsg = "";
         try {
             String path = "/";
             JSONObject params = drive.getParamByPath(path);
             params.put("path", path);
             String response = post(drive, drive.listApi(), params.toString(), false);
-            code = new JSONObject(response).getInt("code");
+            JSONObject json = new JSONObject(response);
+            code = json.getInt("code");
+            if (code != 200) {
+                errMsg = json.optString("message", "");
+            }
         } catch (Exception e) {
         }
         if (code == 401 || code == 403) {
             String loginPath = Path.files() + "/" + drive.getServer().replace("://", "_").replace(":", "_") + ".login";
             File loginFile = new File(loginPath);
             Path.write(loginFile, "\n\n");
+            serverTokenCache.remove(server); // 真登录后二次验证仍失败 → 清缓存, 避免下次误复用
+            String extra = errMsg.isEmpty() ? "" : (" | 服务端: " + errMsg);
+            if (code == 401) {
+                Logger.log("登录失败(401): 用户名/密码/token 无效或已过期, 已清空登录缓存" + extra);
+                Notify.show("登录失败(401): 用户名/密码/token 无效或已过期" + extra);
+            } else {
+                Logger.log("登录失败(403): 已登录但无权访问该路径(可能 guest 权限不足), 已清空登录缓存" + extra);
+                Notify.show("登录失败(403): 已登录但无权访问该路径(可能 guest 权限不足)" + extra);
+            }
             return false;
         }
 
         //服务器相同则用户名密码相同，快速复制登陆结果到其它驱动（TBD：可能引入问题）
         if (!drive.getToken().isEmpty()) {
+            serverTokenCache.put(server, drive.getToken()); // A: 登录成功写入缓存, 同 server 后续线程短路复用
             for (Drive d : drives) {
                 if(drive.getServer().equals(d.getServer())) {
                     d.setToken(drive.getToken());
@@ -499,6 +542,35 @@ public class AListSh extends Spider {
             }
         }
         return true;
+    }
+
+    /**
+     * 执行登录接口调用：解析响应，code!=200 时显示服务端返回的原始 message。
+     *
+     * @return 是否登录成功
+     */
+    private boolean doLogin(Drive drive, JSONObject params, String source) {
+        try {
+            String response = OkHttp.post(drive.loginApi(), params.toString());
+            JSONObject json = new JSONObject(response);
+            int code = json.optInt("code", 200);
+            if (code != 200) {
+                String msg = json.optString("message", "");
+                String info = "登录失败(" + source + "): 服务端 code=" + code;
+                if (!msg.isEmpty()) {
+                    info += " - " + msg;
+                }
+                Logger.log(info);
+                Notify.show(info);
+                return false;
+            }
+            drive.setToken(json.getJSONObject("data").getString("token"));
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            Notify.show("登录失败(" + source + "): 网络异常或凭据无效");
+            return false;
+        }
     }
 
     private boolean loginByConfig(Drive drive) {
@@ -518,11 +590,10 @@ public class AListSh extends Spider {
                 drive.setToken(password);
                 return true;
             } 
-            String response = OkHttp.post(drive.loginApi(), params.toString());
-            drive.setToken(new JSONObject(response).getJSONObject("data").getString("token"));
-            return true;
+            return doLogin(drive, params, "config");
         } catch (Exception e) {
             e.printStackTrace();
+            Notify.show("登录失败(config): 网络异常或凭据无效");
             return false;
         }
     }
@@ -530,25 +601,45 @@ public class AListSh extends Spider {
     private boolean loginByUser(Drive drive) {
         try {
             JSONObject params = new JSONObject();
-            String userName = LoginDlg.showLoginDlg("用户名(留空默认dav)");
-            String password = LoginDlg.showLoginDlg("密码(留空默认1234，\"alist-\"打头会被识别为alist token)");
-            Logger.log("用户名:" + userName + "密码:" + password);
-            userName = userName.isEmpty() ? "dav" : userName;
-            password = password.isEmpty() ? "1234" : password;
             String loginPath = Path.files() + "/" + drive.getServer().replace("://", "_").replace(":", "_") + ".login";
             File loginFile = new File(loginPath);
-            Path.write(loginFile, (userName + "\n" + password).getBytes());
-            params.put("username", userName);
-            params.put("password", password);
-            if (password.startsWith("alist-")) {
-                drive.setToken(password);
-                return true;
-            } 
-            String response = OkHttp.post(drive.loginApi(), params.toString());
-            drive.setToken(new JSONObject(response).getJSONObject("data").getString("token"));
-            return true;
+            // 登录失败重新弹对话框, 最多尝试 3 次
+            for (int attempt = 1; attempt <= 3; attempt++) {
+                String[] cred = LoginDlg.showLoginDlg(
+                        drive.getServer(),
+                        "用户名(留空默认dav)",
+                        "密码(留空默认1234，\"alist-\"打头会被识别为alist token)");
+                if (cred == null) {
+                    Logger.log("登录取消: 用户取消/关闭登录对话框, 中断登录");
+                    return false; // 取消/超时 → 直接中断, 不发请求、不写盘
+                }
+                String userName = cred[0];
+                String password = cred[1];
+                Logger.log("用户名:" + userName + "密码:" + password);
+                userName = userName.isEmpty() ? "dav" : userName;
+                password = password.isEmpty() ? "1234" : password;
+                params.put("username", userName);
+                params.put("password", password);
+                if (password.startsWith("alist-")) {
+                    drive.setToken(password);
+                    Path.write(loginFile, (userName + "\n" + password).getBytes()); // alist- 直通视为成功, 才写盘
+                    return true;
+                }
+                if (doLogin(drive, params, "user")) {
+                    Path.write(loginFile, (userName + "\n" + password).getBytes()); // 成功才写盘
+                    return true;
+                }
+                // 登录失败: 还有剩余次数则重新弹出; 否则结束 (不弹 Toast, 避免顶掉 doLogin 的详细信息)
+                if (attempt < 3) {
+                    Logger.log("登录失败, 第 " + attempt + " 次, 重新弹出登录框");
+                } else {
+                    Logger.log("登录失败, 已达最多 3 次");
+                }
+            }
+            return false;
         } catch (Exception e) {
             e.printStackTrace();
+            Notify.show("登录失败(user): 网络异常或凭据无效");
             return false;
         }
     }
@@ -575,12 +666,16 @@ public class AListSh extends Spider {
             if (password.startsWith("alist-")) {
                 drive.setToken(password);
                 return true;
-            } 
-            String response = OkHttp.post(drive.loginApi(), params.toString());
-            drive.setToken(new JSONObject(response).getJSONObject("data").getString("token"));
+            }
+            if (!doLogin(drive, params, "file")) {
+                // 文件账密登录失败 → 清空 .login, 避免旧错账反复试（下次空则跳过）
+                Path.write(loginFile, "\n\n");
+                return false;
+            }
             return true;
         } catch (Exception e) {
             e.printStackTrace();
+            Notify.show("登录失败(file): 网络异常或凭据无效");
             return false;
         }
     }

--- a/app/src/main/java/com/github/catvod/utils/Notify.java
+++ b/app/src/main/java/com/github/catvod/utils/Notify.java
@@ -1,6 +1,7 @@
 package com.github.catvod.utils;
 
 import android.text.TextUtils;
+import android.view.Gravity;
 import android.widget.Toast;
 
 import com.github.catvod.spider.Init;
@@ -25,6 +26,7 @@ public class Notify {
         if (TextUtils.isEmpty(message)) return;
         if (mToast != null) mToast.cancel();
         mToast = Toast.makeText(Init.context(), message, Toast.LENGTH_LONG);
+        mToast.setGravity(Gravity.CENTER, 0, 0); // 屏幕正中央
         mToast.show();
     }
 }


### PR DESCRIPTION
本轮登录功能重构：

- LoginDlg: 用户名+密码双输入框、显示正在登录的服务器(标题)、永不超时(等用户操作)、取消/返回键中断
- AListSh.loginByUser: 失败重新弹框最多3次、取消中断、失败不落盘(成功才写.login)、登录失败显示服务端code+原始message、重试不覆盖详细信息
- AListSh.loginByFile: 失败清空.login、空则跳过
- AListSh: 按服务器缓存token无TTL, 并发登录短路去重(401/403失效时重登)
- Notify: Toast显示在屏幕正中央

仅包含 3 个登录相关文件，无 jar/WatchSync 混入。