### PR TITLE
refactor(login): 二次验证失败提示归一, 统一显示服务端 code+message

### DIFF
--- a/app/src/main/java/com/github/catvod/spider/AListSh.java
+++ b/app/src/main/java/com/github/catvod/spider/AListSh.java
@@ -521,14 +521,9 @@ public class AListSh extends Spider {
             File loginFile = new File(loginPath);
             Path.write(loginFile, "\n\n");
             serverTokenCache.remove(server); // 真登录后二次验证仍失败 → 清缓存, 避免下次误复用
-            String extra = errMsg.isEmpty() ? "" : (" | 服务端: " + errMsg);
-            if (code == 401) {
-                Logger.log("登录失败(401): 用户名/密码/token 无效或已过期, 已清空登录缓存" + extra);
-                Notify.show("登录失败(401): 用户名/密码/token 无效或已过期" + extra);
-            } else {
-                Logger.log("登录失败(403): 已登录但无权访问该路径(可能 guest 权限不足), 已清空登录缓存" + extra);
-                Notify.show("登录失败(403): 已登录但无权访问该路径(可能 guest 权限不足)" + extra);
-            }
+            String detail = errMsg.isEmpty() ? ("code=" + code) : ("code=" + code + " - " + errMsg);
+            Logger.log("登录失败: " + detail + ", 已清空登录缓存");
+            Notify.show("登录失败: " + detail);
             return false;
         }
 


### PR DESCRIPTION
去掉登录二次验证失败时 401/403 硬编码分叉文案(本地猜测的 token无效/无权访问), 统一展示服务端 code + message：

- Notify/Logger 统一为 `登录失败: code=<code> - <服务端message>`
- errMsg 为空时兜底只显示 `code=xxx`
- 保留 `if(code==401||code==403)` 触发条件不变
- Logger 保留已清空登录缓存动作信息, Notify 只显示 code+message

仅改 AListSh.java 一处。